### PR TITLE
Update gaussian.py default value

### DIFF
--- a/score_models/models/gaussian.py
+++ b/score_models/models/gaussian.py
@@ -6,13 +6,13 @@ from jax import jacfwd
 from jax import numpy as np
 from jax import vmap
 from jax.scipy.stats import norm
-
+from dataclasses import field
 
 class GaussianModel(eqx.Module):
     """Univariate Gaussian score function."""
 
-    mu: np.array = np.array(0.0)
-    log_sigma: np.array = np.array(0.0)
+    mu: np.array = field(default_factory = lambda: np.array(0.0))
+    log_sigma: np.array = field(default_factory = lambda: np.array(0.0))
 
     @eqx.filter_jit
     def __call__(self, x):


### PR DESCRIPTION
Fix for the following dataclasses error:

File /opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/dataclasses.py:815, in _get_field(cls, a_name, a_type, default_kw_only)
    811 # For real fields, disallow mutable defaults.  Use unhashable as a proxy
    812 # indicator for mutability.  Read the __hash__ attribute from the class,
    813 # not the instance.
    814 if f._field_type is _FIELD and f.default.__class__.__hash__ is None:
--> 815     raise ValueError(f'mutable default {type(f.default)} for field '
    816                      f'{f.name} is not allowed: use default_factory')
    818 return f

ValueError: mutable default <class 'jaxlib.xla_extension.ArrayImpl'> for field mu is not allowed: use default_factory